### PR TITLE
[ENG-5229] Update return null when parsing NONE value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 1.2.2
+- Update return null when parsing `NONE` value
+
 ## 1.2.1
 - Fix an issue where user data contains key collisions and parser extracts the wrong info
 

--- a/lib/src/field_parser.dart
+++ b/lib/src/field_parser.dart
@@ -43,11 +43,15 @@ class FieldParser {
   ///
   String? parseString(String key, {bool matchLineStartOnly = true}) {
     final identifier = fieldMapper.fieldFor(key);
-    return LicenseRegex.firstMatch(
+    final result = LicenseRegex.firstMatch(
       pattern: '$identifier(.+)\\b',
       data: data,
       matchLineStartOnly: matchLineStartOnly,
     );
+    if(result == 'NONE'){
+      return null;
+    }
+    return result;
   }
 
   ///

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: drivers_license_parser
 description: This package provides a simple and effective utility for parsing barcodes displayed on the back of drivers license cards issued in the United States and Canada.
-version: 1.2.1
+version: 1.2.2
 homepage: https://github.com/axlehire/drivers_license_parser
 
 environment:

--- a/test/line_endings_test.dart
+++ b/test/line_endings_test.dart
@@ -15,7 +15,7 @@ void main() {
             "DDEN\r\n" +
             "DACJOHN\r\n" +
             "DDFN\r\n" +
-            "DADQUINCY\r\n" +
+            "DADNONE\r\n" +
             "DDGN\r\n" +
             "DCAD\r\n" +
             "DCBNONE\r\n" +
@@ -46,7 +46,7 @@ void main() {
 
         expect(result.version, "08");
         expect(result.lastName, "PUBLIC");
-        expect(result.middleName, "QUINCY");
+        expect(result.middleName, null);
         expect(result.firstName, "JOHN");
         expect(result.eyeColor, EyeColor.green);
         expect(result.streetAddress, "789 E OAK ST");


### PR DESCRIPTION
Return null when parsing NONE value.
