### PR TITLE
feat: add `License` equatability

### DIFF
--- a/lib/src/license.dart
+++ b/lib/src/license.dart
@@ -209,39 +209,40 @@ class License {
           pdf417 == other.pdf417;
 
   @override
-  int get hashCode =>
-      firstName.hashCode ^
-      lastName.hashCode ^
-      middleName.hashCode ^
-      expirationDate.hashCode ^
-      issueDate.hashCode ^
-      dateOfBirth.hashCode ^
-      gender.hashCode ^
-      eyeColor.hashCode ^
-      height.hashCode ^
-      streetAddress.hashCode ^
-      city.hashCode ^
-      state.hashCode ^
-      postalCode.hashCode ^
-      driversLicenseNumber.hashCode ^
-      customerId.hashCode ^
-      uniqueCustomerId.hashCode ^
-      documentId.hashCode ^
-      country.hashCode ^
-      middleNameTruncation.hashCode ^
-      firstNameTruncation.hashCode ^
-      lastNameTruncation.hashCode ^
-      streetAddressSupplement.hashCode ^
-      hairColor.hashCode ^
-      placeOfBirth.hashCode ^
-      auditInformation.hashCode ^
-      inventoryControlNumber.hashCode ^
-      lastNameAlias.hashCode ^
-      firstNameAlias.hashCode ^
-      suffixAlias.hashCode ^
-      suffix.hashCode ^
-      version.hashCode ^
-      pdf417.hashCode;
+  int get hashCode => Object.hashAll([
+        firstName.hashCode,
+        lastName.hashCode,
+        middleName.hashCode,
+        expirationDate.hashCode,
+        issueDate.hashCode,
+        dateOfBirth.hashCode,
+        gender.hashCode,
+        eyeColor.hashCode,
+        height.hashCode,
+        streetAddress.hashCode,
+        city.hashCode,
+        state.hashCode,
+        postalCode.hashCode,
+        driversLicenseNumber.hashCode,
+        customerId.hashCode,
+        uniqueCustomerId.hashCode,
+        documentId.hashCode,
+        country.hashCode,
+        middleNameTruncation.hashCode,
+        firstNameTruncation.hashCode,
+        lastNameTruncation.hashCode,
+        streetAddressSupplement.hashCode,
+        hairColor.hashCode,
+        placeOfBirth.hashCode,
+        auditInformation.hashCode,
+        inventoryControlNumber.hashCode,
+        lastNameAlias.hashCode,
+        firstNameAlias.hashCode,
+        suffixAlias.hashCode,
+        suffix.hashCode,
+        version.hashCode,
+        pdf417.hashCode
+      ]);
 
   @override
   String toString() {

--- a/lib/src/license.dart
+++ b/lib/src/license.dart
@@ -171,6 +171,79 @@ class License {
   }
 
   @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is License &&
+          runtimeType == other.runtimeType &&
+          firstName == other.firstName &&
+          lastName == other.lastName &&
+          middleName == other.middleName &&
+          expirationDate == other.expirationDate &&
+          issueDate == other.issueDate &&
+          dateOfBirth == other.dateOfBirth &&
+          gender == other.gender &&
+          eyeColor == other.eyeColor &&
+          height == other.height &&
+          streetAddress == other.streetAddress &&
+          city == other.city &&
+          state == other.state &&
+          postalCode == other.postalCode &&
+          driversLicenseNumber == other.driversLicenseNumber &&
+          customerId == other.customerId &&
+          uniqueCustomerId == other.uniqueCustomerId &&
+          documentId == other.documentId &&
+          country == other.country &&
+          middleNameTruncation == other.middleNameTruncation &&
+          firstNameTruncation == other.firstNameTruncation &&
+          lastNameTruncation == other.lastNameTruncation &&
+          streetAddressSupplement == other.streetAddressSupplement &&
+          hairColor == other.hairColor &&
+          placeOfBirth == other.placeOfBirth &&
+          auditInformation == other.auditInformation &&
+          inventoryControlNumber == other.inventoryControlNumber &&
+          lastNameAlias == other.lastNameAlias &&
+          firstNameAlias == other.firstNameAlias &&
+          suffixAlias == other.suffixAlias &&
+          suffix == other.suffix &&
+          version == other.version &&
+          pdf417 == other.pdf417;
+
+  @override
+  int get hashCode =>
+      firstName.hashCode ^
+      lastName.hashCode ^
+      middleName.hashCode ^
+      expirationDate.hashCode ^
+      issueDate.hashCode ^
+      dateOfBirth.hashCode ^
+      gender.hashCode ^
+      eyeColor.hashCode ^
+      height.hashCode ^
+      streetAddress.hashCode ^
+      city.hashCode ^
+      state.hashCode ^
+      postalCode.hashCode ^
+      driversLicenseNumber.hashCode ^
+      customerId.hashCode ^
+      uniqueCustomerId.hashCode ^
+      documentId.hashCode ^
+      country.hashCode ^
+      middleNameTruncation.hashCode ^
+      firstNameTruncation.hashCode ^
+      lastNameTruncation.hashCode ^
+      streetAddressSupplement.hashCode ^
+      hairColor.hashCode ^
+      placeOfBirth.hashCode ^
+      auditInformation.hashCode ^
+      inventoryControlNumber.hashCode ^
+      lastNameAlias.hashCode ^
+      firstNameAlias.hashCode ^
+      suffixAlias.hashCode ^
+      suffix.hashCode ^
+      version.hashCode ^
+      pdf417.hashCode;
+
+  @override
   String toString() {
     return '''
 License{

--- a/test/license_test.dart
+++ b/test/license_test.dart
@@ -4,6 +4,55 @@ import 'package:test/test.dart';
 
 void main() {
   group("License", () {
+    group("Equality", () {
+      test("should be equal when all fields match", () {
+        var left = License(
+          driversLicenseNumber: "D123",
+          firstName: "JANE",
+          lastName: "DOE",
+          middleName: "Q",
+          expirationDate: DateTime(2030, 1, 1),
+          issueDate: DateTime(2020, 1, 1),
+          dateOfBirth: DateTime(1990, 1, 1),
+          height: 65.0,
+          streetAddress: "123 MAIN ST",
+          city: "ANYTOWN",
+          state: "CA",
+          postalCode: PostalCode(postalCode: "12345", extension: "6789"),
+          documentId: "DOC-1",
+          version: "8",
+          pdf417: "raw",
+        );
+        var right = License(
+          driversLicenseNumber: "D123",
+          firstName: "JANE",
+          lastName: "DOE",
+          middleName: "Q",
+          expirationDate: DateTime(2030, 1, 1),
+          issueDate: DateTime(2020, 1, 1),
+          dateOfBirth: DateTime(1990, 1, 1),
+          height: 65.0,
+          streetAddress: "123 MAIN ST",
+          city: "ANYTOWN",
+          state: "CA",
+          postalCode: PostalCode(postalCode: "12345", extension: "6789"),
+          documentId: "DOC-1",
+          version: "8",
+          pdf417: "raw",
+        );
+
+        expect(left, equals(right));
+        expect(left.hashCode, equals(right.hashCode));
+      });
+
+      test("should not be equal when a field differs", () {
+        var left = License(driversLicenseNumber: "D123", firstName: "JANE");
+        var right = License(driversLicenseNumber: "D123", firstName: "JOAN");
+
+        expect(left == right, isFalse);
+      });
+    });
+
     group("Acceptability", () {
       group("when the license has yet to be issued", () {
         test("should not be acceptable", () {


### PR DESCRIPTION
Implemented `License`'s `==` and `hashCode` to enable checking whether two `License` instances have equal value.

My primary motivation for this comes from the need to unit test the results of parsing after a bit of pre-processing I have to do to be compatible with scanners that do not give perfectly formatted input.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * License objects now support value-based equality and produce consistent hash codes for reliable comparisons and collections.

* **Tests**
  * Added tests verifying equality and hashCode behavior for identical licenses and inequality when fields differ.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->